### PR TITLE
Add undeclared missing oldpi

### DIFF
--- a/hw2/HW2.ipynb
+++ b/hw2/HW2.ipynb
@@ -317,6 +317,7 @@
     "    pis = []\n",
     "    for it in range(nIt):\n",
     "        Vprev = Vs[-1]\n",
+    "        oldpi = pis[-1] if len(pis) > 0 else None\n",
     "        # YOUR CODE HERE\n",
     "        # Your code should define variables V: the bellman backup applied to Vprev\n",
     "        # and pi: the greedy policy applied to Vprev\n",


### PR DESCRIPTION
To make it consistent with `Vprev`, declare `oldpi`.
Otherwise it will cause an error in later lines start with `nChgActions`... (old and current `pi` comparison)