### PR TITLE
Added tensorboard support, parallelism to hw2

### DIFF
--- a/hw2/logz.py
+++ b/hw2/logz.py
@@ -1,11 +1,9 @@
-import json
-
 """
 
 Some simple logging functionality, inspired by rllab's logging.
 Assumes that each diagnostic gets logged each iteration
 
-Call logz.configure_output_dir() to start logging to a 
+Call logz.configure_output_dir() to start logging to a
 tab-separated-values file (some_folder_name/log.txt)
 
 To load the learning curves, you can do, for example
@@ -15,9 +13,20 @@ A['EpRewMean']
 
 """
 
-import os.path as osp, shutil, time, atexit, os, subprocess
+import copy
+import json
+import os.path as osp
+import shutil
+import time
+import atexit
+import os
 import pickle
+import subprocess
+
+import numpy as np
+import pandas as pd
 import tensorflow as tf
+
 
 color2num = dict(
     gray=30,
@@ -73,7 +82,7 @@ def save_params(params):
     with open(osp.join(G.output_dir, "params.json"), 'w') as out:
         out.write(json.dumps(params, separators=(',\n','\t:\t'), sort_keys=True))
 
-def pickle_tf_vars():  
+def pickle_tf_vars():
     """
     Saves tensorflow variables
     Requires them to be initialized first, also a default session must exist
@@ -81,7 +90,7 @@ def pickle_tf_vars():
     _dict = {v.name : v.eval() for v in tf.global_variables()}
     with open(osp.join(G.output_dir, "vars.pkl"), 'wb') as f:
         pickle.dump(_dict, f)
-    
+
 
 def dump_tabular():
     """
@@ -110,3 +119,111 @@ def dump_tabular():
         G.output_file.flush()
     G.log_current_row.clear()
     G.first_row=False
+
+#============================================================================================#
+# Tensorboard Plotting
+#============================================================================================#
+
+
+def log_scalar(name, val, history_dict, tb_expt=None):
+    """Logs a single scalar value to both the logger and to tensorboard.
+
+    :param name: Name of the logged value.
+    :type name: str
+    :param val: The scalar value being logged and plotted on tb.
+    :type val: int or float
+    :param history_dict: A dict with the list of all the logged
+        values (one for each iteration).
+    :type history_dict: dict(str, list(float))
+    :param tb_expt: The pycrayon tensorboard expt to update.
+    :type tb_expt: pycrayon.crayon.CrayonExperiment or NoneType
+
+    :returns: The history_dict as passed in with the scalar value appended.
+    :rtype: dict(str, list(float))
+
+    Sample input//output ``history_dict``::
+
+        {
+            # List lengths num_iteraions
+            "loss": [1.,1.,-2.,...,],
+            "Return/Average": [3,9,2...,],
+            "Return/Std": [3,0.9,.2.,...,],
+            "Time": [1,2,3...,],
+        }
+    """
+    # Don't mutate the input. Mutation is evil.
+    history_dict = copy.deepcopy(history_dict)
+    log_tabular(name, val)
+    history_dict.setdefault(name, []).append(val)
+    if tb_expt is not None:
+        tb_expt.add_scalar_dict({name: float(val)})
+    return history_dict
+
+
+def log_actions(actions, tb_expt=None):
+    """Log the actions taken by the agent as a histogram in tensorboard.
+
+    :param actions: The actions taken by the agent in the batch.
+    :type actions: np.array(shape=(batch_sz, ac_dim)) or np.array(shape=(batch_sz,))
+    :param tb_expt: As defined in :func:`log_scalar`.
+    """
+    if tb_expt is None:
+        return
+    if len(actions.shape) == 1:
+        actions = actions[:, None]
+    for j in range(actions.shape[1]):
+        tb_expt.add_histogram_value(
+            name='axn/{j}'.format(j=j),
+            hist=actions[:, j].tolist(),
+            tobuild=True,
+        )
+
+
+def log_value_scalars(
+    itr, start_time, returns, loss_val, ep_lengths, timesteps_this_batch,
+    total_timesteps, history_dict, tb_expt=None,
+):
+    """Log the performance values for this iteration.
+
+    :param history_dict: As defined in :func:`log_scalar`.
+    :param tb_expt: As defined in :func:`log_scalar`.
+
+    :returns: history_dict after appending the performance scalar values
+        for this iteration. See also :func:`log_scalar`.
+    :rtype: dict(str, list(float))
+    """
+    hd = history_dict
+    hd = log_scalar('Time', time.time() - start_time, history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('Iteration', itr, history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('loss', loss_val, history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('Return/Avg', np.mean(returns), history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('Return/Std', np.std(returns), history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('Return/Max', np.max(returns), history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('Return/Min', np.min(returns), history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('EpLen/Mean', np.mean(ep_lengths), history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('EpLen/Std', np.std(ep_lengths), history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('Timesteps/ThisBatch', timesteps_this_batch, history_dict=hd, tb_expt=tb_expt)
+    hd = log_scalar('Timesteps/SoFar', total_timesteps, history_dict=hd, tb_expt=tb_expt)
+    return hd
+
+
+def plot_tb_avg_history(tb_avg_expt, history_dicts):
+    """Plots the average metrics over different expt runs in tensorboard.
+
+    :param tb_avg_expt: The pycrayon tensorboard expt corresponding
+        to the average of the run.
+    :type tb_avg_expt: pycrayon.crayon.CrayonExperiment or NoneType
+    :param history_dicts: List of the performance history dicts
+        one for each experiment run. See :func:`log_scalar` for the
+        structure of a single entry in the list.
+    :type history_dicts: list(dict(str, list(float)))
+    """
+    if tb_avg_expt is None:
+        return
+    avg_df = pd.DataFrame(history_dicts[0])
+    for hd in history_dicts[1:]:
+        avg_df += pd.DataFrame(hd)
+    avg_df /= len(history_dicts)
+    for field in avg_df.columns:
+        for val in avg_df[field]:
+            tb_avg_expt.add_scalar_dict({field: float(val)})

--- a/hw2/tensorboard_pycrayon.py
+++ b/hw2/tensorboard_pycrayon.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Tensorboard interface for python with pycrayon
+
+https://medium.com/@vishnups/pycrayon-tensorboard-741fbe05b348
+
+Set up tensorboard
+------------------
+
+.. code-block:: bash
+
+    pip install pycrayon
+    docker pull alband/crayon
+    # Tensorboard will be served on localhost:9118
+    docker run -p 9118:8888 -p 9119:8889 --name crayon alband/crayon
+"""
+import collections
+import datetime
+import socket
+
+import pycrayon
+
+
+CrayonSettings = collections.namedtuple('CrayonSettings', ['host', 'port'])
+CRAYON_SETTINGS = CrayonSettings(host='localhost', port='9119')
+
+
+def get_experiments(names, settings=CRAYON_SETTINGS):
+    """Creates pycrayon experiments object to log data to.
+    """
+    experiment_date = datetime.datetime.now().strftime('%Y.%m.%d-%H:%M:%S')
+    client = get_crayon_client(settings=settings)
+    return {
+        each_name: client.create_experiment(
+            '{name};{dt}_{host}'.format(
+                dt=experiment_date,
+                host=socket.gethostname(),
+                name=each_name,
+            )
+        )
+        for each_name in names
+    }
+
+
+def get_experiment(name, settings=CRAYON_SETTINGS):
+    """Creates a pycrayon experiment object to log data to.
+    """
+    experiment_date = datetime.datetime.now().strftime('%Y.%m.%d-%H:%M:%S')
+    experiment_name = '{name};{dt}_{host}'.format(
+        dt=experiment_date,
+        host=socket.gethostname(),
+        name=name,
+    )
+    return get_crayon_client(settings=settings).create_experiment(experiment_name)
+
+
+def get_crayon_client(settings=CRAYON_SETTINGS):
+    return pycrayon.CrayonClient(hostname=settings.host, port=settings.port)
+
+
+def clear_expts(settings=CRAYON_SETTINGS):
+    get_crayon_client(settings=settings).remove_all_experiments()


### PR DESCRIPTION
Changes
=======
Fixes
-----
- Fixed some trailing commas and trailing spaces.
- Fixed some pep8 issues with blank lines.
- Added more documentation.

Feature Additions
------------------
Works in py2 and py3.

1. Added parallelism. The earlier implementation was calling `process.join()` within a for loop essentially running in serial (I think the purpose was not parallelism but to address some tensorflow issue).
Parallelism is off by default and can be turned on by setting the `--num_parallel` CLI to a number greater than `1`. The code will parallelize across each experiment. It will at most spawn off `min(num_parallel, num_experiments)`.
2. Added default logging to tensorboard using pyrcrayon which is agnostic the deep learning framework being used (communication happens using a REST API).
* Setting up tensorboard is 2 docker commands.
* The user can turn off tensorboard logging using the `--no_tb` CLI.
* This does require the user to install `pyrcrayon` (works on both py2 and py3).
* The script will log all each experiment with the name `{exp_name}-{i};{datetime}_{hostname}` where `i` is the experiment number or `avg` for the average of all the runs in tensorboard.
* The user can delete existing experiments with `--clear_tb_expt` CLI flag.
**Tabs**
![Tabs](https://user-images.githubusercontent.com/5592447/38947357-46882930-42f1-11e8-8ada-98190e1c07be.png)
**All the experiments**
![All the runs](https://user-images.githubusercontent.com/5592447/38947405-74c64458-42f1-11e8-902e-d23668a045bf.png)
**Average of each setting**
![Average of each setting](https://user-images.githubusercontent.com/5592447/38947417-80f1112c-42f1-11e8-9afc-75079c1ec63f.png)
**Actions as histogram**
This does not plot the avg histogram but each experiment run separately.
![image](https://user-images.githubusercontent.com/5592447/38947481-bb09c926-42f1-11e8-98db-2972be2747a2.png)

Code changes needed
-----------------------
- Added a module, `tensorboard_pyrcayon.py` with the tensorboard pycrayon utilities.
- Updated `logz.py` with functions needed for tensorboard plotting.
- The `train_PG` function now returns a dict with a history of the scalar values which we average across all the experiment runs.

Testing
=====
Manual only. I used a working solution (not sure if its a good idea to add it here so refraining from it) and ran it under the following scenarios.

1. Run without a tensorboard running.
``` bash
$ python train_pg.py InvertedPendulum-v1 -n 10 -b 500 -e 2 --exp_name py2-invpen-lr0.001  -rtg --n_layers 3 --size 64 --discount 0.99 -lr 0.001  --num_parallel 2
Running experiment with seed 1
Running experiment with seed 11
Logging data to data/py2-invpen-lr0.01_InvertedPendulum-v1_18-04-2018_10-44-35/1/log.txt
Logging data to data/py2-invpen-lr0.01_InvertedPendulum-v1_18-04-2018_10-44-35/11/log.txt
Traceback (most recent call last):
  File "train_pg.py", line 674, in <module>
    main()
  File "train_pg.py", line 555, in main
    history_dicts = list(map_func(train_PG_star, train_kwargs_list))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/pool.py", line 251, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/pool.py", line 567, in get
    raise self._value
ValueError: The server at localhost:9119 does not appear to be up!
```
2. Run without tensorboard running with `--no_tb`
Verified in py2 and py3
``` bash
$ python train_pg.py InvertedPendulum-v1 -n 10 -b 500 -e 2 --exp_name py2-invpen-lr0.001  -rtg --n_layers 3 --size 64 --discount 0.99 -lr 0.001  --num_parallel 2 --no_tb
...
********** Iteration 9 ************
-----------------------------------------
|                Time |            4.66 |
|           Iteration |               9 |
|                loss |         -0.0497 |
|          Return/Avg |            15.2 |
|          Return/Std |             9.8 |
|          Return/Max |              48 |
|          Return/Min |               4 |
|          EpLen/Mean |            15.2 |
|           EpLen/Std |             9.8 |
| Timesteps/ThisBatch |             502 |
|     Timesteps/SoFar |        5.07e+03 |
-----------------------------------------
$
```
3. Run with tensorboard
I have tensorboard running in the background with `$ docker run -p 9118:8888 -p 9119:8889 --name crayon alband/crayon`
``` bash
$ python train_pg.py InvertedPendulum-v1 -n 10 -b 500 -e 2 --exp_name py2-invpen-lr0.001  -rtg --n_layers 3 --size 64 --discount 0.99 -lr 0.001  --num_parallel 2
```
I see
![image](https://user-images.githubusercontent.com/5592447/38949187-86d14cc4-42f6-11e8-8e0b-8da67edb055e.png)

* Also ran another run and verified I saw two results in tensorboard.
* I reran the command a third time with `--clear_tb_expt` and verified that the previous runs were erased from tensorboard.